### PR TITLE
Update the schema to use column name instead of v_{index} format for column id

### DIFF
--- a/src/TableauConnector.js
+++ b/src/TableauConnector.js
@@ -55,6 +55,7 @@ export default class TableauConnector {
     this.connector.getData = this.getData
     this.submit = tableau.submit
     axios.defaults.headers.post['Content-Type'] = 'application/x-www-form-urlencoded'
+    axios.defaults.headers.post['Accept'] = 'application/json';
     tableau.registerConnector(this.connector)
   }
 

--- a/tests/TableauConnector.spec.js
+++ b/tests/TableauConnector.spec.js
@@ -57,7 +57,22 @@ it('Returns default tableauschema type', () => {
   expect(connector.getDatatype('randommissingdatatype')).toBe('string')
 })
 
-it('Formats the schema correctly for a non-query', (done) => {
+it('Formats the schema correctly for a non-query, no version', (done) => {
+  axios.__setMockResponse(schemaData)
+  const connector = new TableauConnector()
+  connector.setConnectionData('test/1234', 'schema-test')
+  const tempConnectionData = JSON.parse(tableau.connectionData)
+  tempConnectionData.version = null
+  tableau.connectionData = JSON.stringify(tempConnectionData)
+  connector.getSchema((schema) => {
+    expect(schema).toHaveLength(3)
+    expect(schema).toMatchSnapshot()
+
+    done()
+  })
+})
+
+it('Formats the schema correctly for a non-query, with version', (done) => {
   axios.__setMockResponse(schemaData)
   const connector = new TableauConnector()
   connector.setConnectionData('test/1234', 'schema-test')

--- a/tests/__snapshots__/TableauConnector.spec.js.snap
+++ b/tests/__snapshots__/TableauConnector.spec.js.snap
@@ -65,10 +65,10 @@ Array [
 ]
 `;
 
-exports[`test Formats the schema correctly for a non-query 1`] = `
+exports[`test Formats the schema correctly for a non-query, no version 1`] = `
 Array [
   Object {
-    "alias": "AnIntrotodata.worldDatasetChangeLog-Sheet1.csv/AnIntrotodata.worldDatasetChangeLog-Sheet1",
+    "alias": "anintrotodata_worlddatasetchangelog_sheet1",
     "columns": Array [
       Object {
         "alias": "Date",
@@ -81,10 +81,10 @@ Array [
         "id": "v_1",
       },
     ],
-    "id": "AnIntrotodataworldDatasetChangeLogSheet1csvAnIntrotodataworldDatasetChangeLogSheet1",
+    "id": "anintrotodataworlddatasetchangelogsheet1",
   },
   Object {
-    "alias": "DataDotWorldBBallStats.csv/DataDotWorldBBallStats",
+    "alias": "datadotworldbballstats",
     "columns": Array [
       Object {
         "alias": "Name",
@@ -102,10 +102,10 @@ Array [
         "id": "v_2",
       },
     ],
-    "id": "DataDotWorldBBallStatscsvDataDotWorldBBallStats",
+    "id": "datadotworldbballstats",
   },
   Object {
-    "alias": "DataDotWorldBBallTeam.csv/DataDotWorldBBallTeam",
+    "alias": "datadotworldbballteam",
     "columns": Array [
       Object {
         "alias": "Name",
@@ -123,7 +123,70 @@ Array [
         "id": "v_2",
       },
     ],
-    "id": "DataDotWorldBBallTeamcsvDataDotWorldBBallTeam",
+    "id": "datadotworldbballteam",
+  },
+]
+`;
+
+exports[`test Formats the schema correctly for a non-query, with version 1`] = `
+Array [
+  Object {
+    "alias": "anintrotodata_worlddatasetchangelog_sheet1",
+    "columns": Array [
+      Object {
+        "alias": "Date",
+        "dataType": "date",
+        "id": "date",
+      },
+      Object {
+        "alias": "Change",
+        "dataType": "string",
+        "id": "change",
+      },
+    ],
+    "id": "anintrotodataworlddatasetchangelogsheet1",
+  },
+  Object {
+    "alias": "datadotworldbballstats",
+    "columns": Array [
+      Object {
+        "alias": "Name",
+        "dataType": "string",
+        "id": "name",
+      },
+      Object {
+        "alias": "PointsPerGame",
+        "dataType": "float",
+        "id": "pointspergame",
+      },
+      Object {
+        "alias": "AssistsPerGame",
+        "dataType": "float",
+        "id": "assistspergame",
+      },
+    ],
+    "id": "datadotworldbballstats",
+  },
+  Object {
+    "alias": "datadotworldbballteam",
+    "columns": Array [
+      Object {
+        "alias": "Name",
+        "dataType": "string",
+        "id": "name",
+      },
+      Object {
+        "alias": "Height",
+        "dataType": "string",
+        "id": "height",
+      },
+      Object {
+        "alias": "Handedness",
+        "dataType": "string",
+        "id": "handedness",
+      },
+    ],
+    "id": "datadotworldbballteam",
   },
 ]
 `;

--- a/tests/apiResponseData.js
+++ b/tests/apiResponseData.js
@@ -20,285 +20,160 @@
 export const schemaData = {
   "query_text": "SELECT * FROM `TableColumns`",
   "query_lang": "SQL",
-  "metadata": [
-    {
-      "agent": "tester",
-      "name": "tableId",
-      "type": "http://www.w3.org/2001/XMLSchema#string",
-      "dataset": "intro-data-set",
-      "table": "TableColumns"
-    },
-    {
-      "agent": "tester",
-      "name": "tableName",
-      "type": "http://www.w3.org/2001/XMLSchema#string",
-      "dataset": "intro-data-set",
-      "table": "TableColumns"
-    },
-    {
-      "agent": "tester",
-      "name": "columnIndex",
-      "type": "http://www.w3.org/2001/XMLSchema#string",
-      "dataset": "intro-data-set",
-      "table": "TableColumns"
-    },
-    {
-      "agent": "tester",
-      "name": "columnName",
-      "type": "http://www.w3.org/2001/XMLSchema#string",
-      "dataset": "intro-data-set",
-      "table": "TableColumns"
-    },
-    {
-      "agent": "tester",
-      "name": "columnDatatype",
-      "type": "http://www.w3.org/2001/XMLSchema#string",
-      "dataset": "intro-data-set",
-      "table": "TableColumns"
-    },
-    {
-      "agent": "tester",
-      "name": "columnNullable",
-      "type": "http://www.w3.org/2001/XMLSchema#string",
-      "dataset": "intro-data-set",
-      "table": "TableColumns"
-    }
-  ],
+
+  "metadata": [{
+    "agent": "tester",
+    "name": "tableId",
+    "type": "http://www.w3.org/2001/XMLSchema#string",
+    "dataset": "intro-data-set",
+    "table": "TableColumns"
+  }, {
+    "agent": "tester",
+    "name": "tableName",
+    "type": "http://www.w3.org/2001/XMLSchema#string",
+    "dataset": "intro-data-set",
+    "table": "TableColumns"
+  }, {
+    "agent": "tester",
+    "name": "columnIndex",
+    "type": "http://www.w3.org/2001/XMLSchema#string",
+    "dataset": "intro-data-set",
+    "table": "TableColumns"
+  }, {
+    "agent": "tester",
+    "name": "columnName",
+    "type": "http://www.w3.org/2001/XMLSchema#string",
+    "dataset": "intro-data-set",
+    "table": "TableColumns"
+  }, {
+    "agent": "tester",
+    "name": "columnTitle",
+    "type": "http://www.w3.org/2001/XMLSchema#string",
+    "dataset": "intro-data-set",
+    "table": "TableColumns"
+  }, {
+    "agent": "tester",
+    "name": "columnDescription",
+    "type": "http://www.w3.org/2001/XMLSchema#string",
+    "dataset": "intro-data-set",
+    "table": "TableColumns"
+  }, {
+    "agent": "tester",
+    "name": "columnDatatype",
+    "type": "http://www.w3.org/2001/XMLSchema#string",
+    "dataset": "intro-data-set",
+    "table": "TableColumns"
+  }, {
+    "agent": "tester",
+    "name": "columnNullable",
+    "type": "http://www.w3.org/2001/XMLSchema#string",
+    "dataset": "intro-data-set",
+    "table": "TableColumns"
+  }, {
+    "agent": "tester",
+    "name": "owner",
+    "type": "http://www.w3.org/2001/XMLSchema#string",
+    "dataset": "intro-data-set",
+    "table": "TableColumns"
+  }, {
+    "agent": "tester",
+    "name": "dataset",
+    "type": "http://www.w3.org/2001/XMLSchema#string",
+    "dataset": "intro-data-set",
+    "table": "TableColumns"
+  }],
   "head": {
-    "vars": [
-      "v_0",
-      "v_1",
-      "v_2",
-      "v_3",
-      "v_4",
-      "v_5"
-    ]
+    "vars": ["v_0", "v_1", "v_2", "v_3", "v_4", "v_5", "v_6", "v_7", "v_8", "v_9"]
   },
   "results": {
     "bindings": [
       {
-        "v_0": {
-          "type": "literal",
-          "value": "AnIntrotodata.worldDatasetChangeLog-Sheet1.csv/AnIntrotodata.worldDatasetChangeLog-Sheet1"
-        },
-        "v_1": {
-          "type": "literal",
-          "value": "AnIntrotodata.worldDatasetChangeLog-Sheet1"
-        },
-        "v_2": {
-          "type": "literal",
-          "datatype": "http://www.w3.org/2001/XMLSchema#integer",
-          "value": "1"
-        },
-        "v_3": {
-          "type": "literal",
-          "value": "Date"
-        },
-        "v_4": {
-          "type": "literal",
-          "value": "http://www.w3.org/2001/XMLSchema#date"
-        },
-        "v_5": {
-          "type": "literal",
-          "datatype": "http://www.w3.org/2001/XMLSchema#boolean",
-          "value": "false"
-        }
+        "v_0": { "type": "literal", "value": "anintrotodata_worlddatasetchangelog_sheet1" },
+        "v_1": { "type": "literal", "value": "anintrotodata_worlddatasetchangelog_sheet1" },
+        "v_2": { "type": "literal", "datatype": "http://www.w3.org/2001/XMLSchema#integer", "value": "1" },
+        "v_3": { "type": "literal", "value": "date" },
+        "v_4": { "type": "literal", "value": "Date" },
+        "v_6": { "type": "uri", "value": "http://www.w3.org/2001/XMLSchema#date" },
+        "v_7": { "type": "literal", "datatype": "http://www.w3.org/2001/XMLSchema#boolean", "value": "false" },
+        "v_8": { "type": "literal", "value": "tester" },
+        "v_9": { "type": "literal", "value": "intro-data-set" }
       },
       {
-        "v_0": {
-          "type": "literal",
-          "value": "AnIntrotodata.worldDatasetChangeLog-Sheet1.csv/AnIntrotodata.worldDatasetChangeLog-Sheet1"
-        },
-        "v_1": {
-          "type": "literal",
-          "value": "AnIntrotodata.worldDatasetChangeLog-Sheet1"
-        },
-        "v_2": {
-          "type": "literal",
-          "datatype": "http://www.w3.org/2001/XMLSchema#integer",
-          "value": "2"
-        },
-        "v_3": {
-          "type": "literal",
-          "value": "Change"
-        },
-        "v_4": {
-          "type": "literal",
-          "value": "http://www.w3.org/2001/XMLSchema#string"
-        },
-        "v_5": {
-          "type": "literal",
-          "datatype": "http://www.w3.org/2001/XMLSchema#boolean",
-          "value": "false"
-        }
+        "v_0": { "type": "literal", "value": "anintrotodata_worlddatasetchangelog_sheet1" },
+        "v_1": { "type": "literal", "value": "anintrotodata_worlddatasetchangelog_sheet1" },
+        "v_2": { "type": "literal", "datatype": "http://www.w3.org/2001/XMLSchema#integer", "value": "2" },
+        "v_3": { "type": "literal", "value": "change" },
+        "v_4": { "type": "literal", "value": "Change" },
+        "v_6": { "type": "uri", "value": "http://www.w3.org/2001/XMLSchema#string" },
+        "v_7": { "type": "literal", "datatype": "http://www.w3.org/2001/XMLSchema#boolean", "value": "false" },
+        "v_8": { "type": "literal", "value": "tester" },
+        "v_9": { "type": "literal", "value": "intro-data-set" }
       },
       {
-        "v_0": {
-          "type": "literal",
-          "value": "DataDotWorldBBallStats.csv/DataDotWorldBBallStats"
-        },
-        "v_1": {
-          "type": "literal",
-          "value": "DataDotWorldBBallStats"
-        },
-        "v_2": {
-          "type": "literal",
-          "datatype": "http://www.w3.org/2001/XMLSchema#integer",
-          "value": "1"
-        },
-        "v_3": {
-          "type": "literal",
-          "value": "Name"
-        },
-        "v_4": {
-          "type": "literal",
-          "value": "http://www.w3.org/2001/XMLSchema#string"
-        },
-        "v_5": {
-          "type": "literal",
-          "datatype": "http://www.w3.org/2001/XMLSchema#boolean",
-          "value": "false"
-        }
+        "v_0": { "type": "literal", "value": "datadotworldbballstats" },
+        "v_1": { "type": "literal", "value": "datadotworldbballstats" },
+        "v_2": { "type": "literal", "datatype": "http://www.w3.org/2001/XMLSchema#integer", "value": "1" },
+        "v_3": { "type": "literal", "value": "name" },
+        "v_4": { "type": "literal", "value": "Name" },
+        "v_6": { "type": "uri", "value": "http://www.w3.org/2001/XMLSchema#string" },
+        "v_7": { "type": "literal", "datatype": "http://www.w3.org/2001/XMLSchema#boolean", "value": "false" },
+        "v_8": { "type": "literal", "value": "tester" },
+        "v_9": { "type": "literal", "value": "intro-data-set" }
       },
       {
-        "v_0": {
-          "type": "literal",
-          "value": "DataDotWorldBBallStats.csv/DataDotWorldBBallStats"
-        },
-        "v_1": {
-          "type": "literal",
-          "value": "DataDotWorldBBallStats"
-        },
-        "v_2": {
-          "type": "literal",
-          "datatype": "http://www.w3.org/2001/XMLSchema#integer",
-          "value": "2"
-        },
-        "v_3": {
-          "type": "literal",
-          "value": "PointsPerGame"
-        },
-        "v_4": {
-          "type": "literal",
-          "value": "http://www.w3.org/2001/XMLSchema#decimal"
-        },
-        "v_5": {
-          "type": "literal",
-          "datatype": "http://www.w3.org/2001/XMLSchema#boolean",
-          "value": "true"
-        }
+        "v_0": { "type": "literal", "value": "datadotworldbballstats" },
+        "v_1": { "type": "literal", "value": "datadotworldbballstats" },
+        "v_2": { "type": "literal", "datatype": "http://www.w3.org/2001/XMLSchema#integer", "value": "2" },
+        "v_3": { "type": "literal", "value": "pointspergame" },
+        "v_4": { "type": "literal", "value": "PointsPerGame" },
+        "v_6": { "type": "uri", "value": "http://www.w3.org/2001/XMLSchema#decimal" },
+        "v_7": { "type": "literal", "datatype": "http://www.w3.org/2001/XMLSchema#boolean", "value": "false" },
+        "v_8": { "type": "literal", "value": "tester" },
+        "v_9": { "type": "literal", "value": "intro-data-set" }
       },
       {
-        "v_0": {
-          "type": "literal",
-          "value": "DataDotWorldBBallStats.csv/DataDotWorldBBallStats"
-        },
-        "v_1": {
-          "type": "literal",
-          "value": "DataDotWorldBBallStats"
-        },
-        "v_2": {
-          "type": "literal",
-          "datatype": "http://www.w3.org/2001/XMLSchema#integer",
-          "value": "3"
-        },
-        "v_3": {
-          "type": "literal",
-          "value": "AssistsPerGame"
-        },
-        "v_4": {
-          "type": "literal",
-          "value": "http://www.w3.org/2001/XMLSchema#decimal"
-        },
-        "v_5": {
-          "type": "literal",
-          "datatype": "http://www.w3.org/2001/XMLSchema#boolean",
-          "value": "true"
-        }
+        "v_0": { "type": "literal", "value": "datadotworldbballstats" },
+        "v_1": { "type": "literal", "value": "datadotworldbballstats" },
+        "v_2": { "type": "literal", "datatype": "http://www.w3.org/2001/XMLSchema#integer", "value": "3" },
+        "v_3": { "type": "literal", "value": "assistspergame" },
+        "v_4": { "type": "literal", "value": "AssistsPerGame" },
+        "v_6": { "type": "uri", "value": "http://www.w3.org/2001/XMLSchema#decimal" },
+        "v_7": { "type": "literal", "datatype": "http://www.w3.org/2001/XMLSchema#boolean", "value": "false" },
+        "v_8": { "type": "literal", "value": "tester" },
+        "v_9": { "type": "literal", "value": "intro-data-set" }
       },
       {
-        "v_0": {
-          "type": "literal",
-          "value": "DataDotWorldBBallTeam.csv/DataDotWorldBBallTeam"
-        },
-        "v_1": {
-          "type": "literal",
-          "value": "DataDotWorldBBallTeam"
-        },
-        "v_2": {
-          "type": "literal",
-          "datatype": "http://www.w3.org/2001/XMLSchema#integer",
-          "value": "1"
-        },
-        "v_3": {
-          "type": "literal",
-          "value": "Name"
-        },
-        "v_4": {
-          "type": "literal",
-          "value": "http://www.w3.org/2001/XMLSchema#string"
-        },
-        "v_5": {
-          "type": "literal",
-          "datatype": "http://www.w3.org/2001/XMLSchema#boolean",
-          "value": "false"
-        }
+        "v_0": { "type": "literal", "value": "datadotworldbballteam" },
+        "v_1": { "type": "literal", "value": "datadotworldbballteam" },
+        "v_2": { "type": "literal", "datatype": "http://www.w3.org/2001/XMLSchema#integer", "value": "1" },
+        "v_3": { "type": "literal", "value": "name" },
+        "v_4": { "type": "literal", "value": "Name" },
+        "v_6": { "type": "uri", "value": "http://www.w3.org/2001/XMLSchema#string" },
+        "v_7": { "type": "literal", "datatype": "http://www.w3.org/2001/XMLSchema#boolean", "value": "false" },
+        "v_8": { "type": "literal", "value": "tester" },
+        "v_9": { "type": "literal", "value": "intro-data-set" }
       },
       {
-        "v_0": {
-          "type": "literal",
-          "value": "DataDotWorldBBallTeam.csv/DataDotWorldBBallTeam"
-        },
-        "v_1": {
-          "type": "literal",
-          "value": "DataDotWorldBBallTeam"
-        },
-        "v_2": {
-          "type": "literal",
-          "datatype": "http://www.w3.org/2001/XMLSchema#integer",
-          "value": "2"
-        },
-        "v_3": {
-          "type": "literal",
-          "value": "Height"
-        },
-        "v_4": {
-          "type": "literal",
-          "value": "http://www.w3.org/2001/XMLSchema#string"
-        },
-        "v_5": {
-          "type": "literal",
-          "datatype": "http://www.w3.org/2001/XMLSchema#boolean",
-          "value": "true"
-        }
+        "v_0": { "type": "literal", "value": "datadotworldbballteam" },
+        "v_1": { "type": "literal", "value": "datadotworldbballteam" },
+        "v_2": { "type": "literal", "datatype": "http://www.w3.org/2001/XMLSchema#integer", "value": "2" },
+        "v_3": { "type": "literal", "value": "height" },
+        "v_4": { "type": "literal", "value": "Height" },
+        "v_6": { "type": "uri", "value": "http://www.w3.org/2001/XMLSchema#string" },
+        "v_7": { "type": "literal", "datatype": "http://www.w3.org/2001/XMLSchema#boolean", "value": "true" },
+        "v_8": { "type": "literal", "value": "tester" },
+        "v_9": { "type": "literal", "value": "intro-data-set" }
       },
       {
-        "v_0": {
-          "type": "literal",
-          "value": "DataDotWorldBBallTeam.csv/DataDotWorldBBallTeam"
-        },
-        "v_1": {
-          "type": "literal",
-          "value": "DataDotWorldBBallTeam"
-        },
-        "v_2": {
-          "type": "literal",
-          "datatype": "http://www.w3.org/2001/XMLSchema#integer",
-          "value": "3"
-        },
-        "v_3": {
-          "type": "literal",
-          "value": "Handedness"
-        },
-        "v_4": {
-          "type": "literal",
-          "value": "http://www.w3.org/2001/XMLSchema#string"
-        },
-        "v_5": {
-          "type": "literal",
-          "datatype": "http://www.w3.org/2001/XMLSchema#boolean",
-          "value": "false"
-        }
+        "v_0": { "type": "literal", "value": "datadotworldbballteam" },
+        "v_1": { "type": "literal", "value": "datadotworldbballteam" },
+        "v_2": { "type": "literal", "datatype": "http://www.w3.org/2001/XMLSchema#integer", "value": "3" },
+        "v_3": { "type": "literal", "value": "handedness" },
+        "v_4": { "type": "literal", "value": "Handedness" },
+        "v_6": { "type": "uri", "value": "http://www.w3.org/2001/XMLSchema#string" },
+        "v_7": { "type": "literal", "datatype": "http://www.w3.org/2001/XMLSchema#boolean", "value": "false" },
+        "v_8": { "type": "literal", "value": "tester" },
+        "v_9": { "type": "literal", "value": "intro-data-set" }
       }
     ]
   }


### PR DESCRIPTION
The schema passed to Tableau for new connections will now use the data.world column name for the Tableau column id as well as the data.world column title for the Tableau column alias.

Existing connections will continue to use the v_{index} format for the column ids.