### PR TITLE
Add failureCallback to getSchema

### DIFF
--- a/__mocks__/axios.js
+++ b/__mocks__/axios.js
@@ -6,14 +6,24 @@ const __setMockResponse = (responseData) => {
   mockResponse.data = responseData
 }
 
+const __rejectNext = () => {
+  mockResponse.reject = true
+}
+
 const post = () => {
-  return new Promise(function (resolve) {
-    resolve(mockResponse)
+  return new Promise((resolve, reject) => {
+    if (mockResponse.reject) {
+      mockResponse.reject = false
+      reject()
+    } else {
+      resolve(mockResponse)
+    }
   })
 }
 
 export default {
   __setMockResponse,
+  __rejectNext,
   post,
   defaults: {
     headers: {

--- a/src/TableauConnector.js
+++ b/src/TableauConnector.js
@@ -134,7 +134,7 @@ export default class TableauConnector {
           resolve()
         }
         reject()
-      })
+      }, reject)
     })
   }
 
@@ -245,7 +245,7 @@ export default class TableauConnector {
     return datasetTables
   }
 
-  getSchema = (callback) => {
+  getSchema = (callback, failureCallback) => {
     let query = this.getQuery(queryTable)
     axios.post(this.getApiEndpoint(), queryString.stringify({query})).then((resp) => {
       if (this.isCustomQuery()) {
@@ -258,9 +258,13 @@ export default class TableauConnector {
         callback(this.getSchemaForDataset(resp))
       }
     }).catch((error) => {
-      tableau.log(error)
-      tableau.log('There was an error retrieving the schema')
-      tableau.abortWithError(error)
+      if (failureCallback) {
+        failureCallback && failureCallback(error)
+      } else {
+        tableau.log(error)
+        tableau.log('There was an error retrieving the schema')
+        tableau.abortWithError(error)
+      }
     })
   }
 

--- a/tests/TableauConnector.spec.js
+++ b/tests/TableauConnector.spec.js
@@ -221,3 +221,10 @@ it('rejects invalid column names', (done) => {
     done()
   })
 })
+
+it ('fails verification if getSchema call fails', (done) => {
+  axios.__rejectNext()
+  const connector = new TableauConnector()
+  connector.setConnectionData('test/1234', 'sql-schema-test')
+  connector.verify().catch(done)
+})


### PR DESCRIPTION
Use a `failureCallback` on `getSchema` so that `verify` can detect an auth failure.  The normal "error as first parameter in a callback" paradigm cannot be used here because the getSchema function must match the function signature dictated by Tableau.