### PR TITLE
Improve (not fix) auth dead-end

### DIFF
--- a/__mocks__/axios.js
+++ b/__mocks__/axios.js
@@ -1,5 +1,13 @@
 import Promise from 'promise'
 
+const interceptors = {
+  response: {}
+}
+interceptors.response.use = (success, failure) => {
+  interceptors.success = success
+  interceptors.failure = failure
+}
+
 let mockResponse = {}
 
 const __setMockResponse = (responseData) => {
@@ -10,13 +18,24 @@ const __rejectNext = () => {
   mockResponse.reject = true
 }
 
+const get = () => {
+  return new Promise((resolve, reject) => {
+    if (mockResponse.reject) {
+      mockResponse.reject = false
+      reject(interceptors.failure())
+    } else {
+      resolve(interceptors.success(mockResponse))
+    }
+  })
+}
+
 const post = () => {
   return new Promise((resolve, reject) => {
     if (mockResponse.reject) {
       mockResponse.reject = false
-      reject()
+      reject(interceptors.failure())
     } else {
-      resolve(mockResponse)
+      resolve(interceptors.success(mockResponse))
     }
   })
 }
@@ -24,7 +43,9 @@ const post = () => {
 export default {
   __setMockResponse,
   __rejectNext,
+  interceptors,
   post,
+  get,
   defaults: {
     headers: {
       common: {},

--- a/src/App.js
+++ b/src/App.js
@@ -48,21 +48,21 @@ class App extends Component {
     this.isTableau = window.tableauVersionBootstrap || forceTableau
 
     this.state = {
-      hasAuth: false,
+      interactivePhase: false,
       datasetName: dataset_name,
       query,
       queryType
     }
   }
 
-  onConnectorReady (hasAuth) {
+  onConnectorReady (interactivePhase) {
     this.setState({
-      hasAuth
+      interactivePhase
     })
   }
 
   render () {
-    const {hasAuth, datasetName, query, queryType} = this.state
+    const {interactivePhase, datasetName, query, queryType} = this.state
     const dataset = datasetName ? `https://data.world/${datasetName}` : null
 
     if (!this.isTableau) {
@@ -70,7 +70,7 @@ class App extends Component {
     }
 
     return (
-      hasAuth ? <TableauConnectorForm
+      interactivePhase ? <TableauConnectorForm
         connector={this.connector}
         dataset={dataset}
         query={query}

--- a/src/TableauConnector.js
+++ b/src/TableauConnector.js
@@ -70,7 +70,7 @@ class TableauConnector {
 
   authenticate () {
     utils.log('START: Authenticate')
-    if (this.code) {
+    if (this.code && tableau.phase !== tableau.phaseEnum.gatherDataPhase) {
       utils.log('SUCCESS: Authenticate (oauth)')
       const code = this.code
       this.code = null // Code can only be used once
@@ -93,9 +93,7 @@ class TableauConnector {
         })
         .catch(() => {
           utils.log('FAILURE: Validate access')
-          // TODO forget on any 401 response
-          auth.storeApiKey('')
-          tableau.abortForAuth()
+          tableau.abortForAuth('The data.world auth token expired or was revoked')
         })
     } else {
       utils.log('SUCCESS: Validate access (not needed)')

--- a/src/TableauConnector.js
+++ b/src/TableauConnector.js
@@ -70,13 +70,15 @@ class TableauConnector {
 
   authenticate () {
     utils.log('START: Authenticate')
-    const apiKey = auth.getApiKey()
-    if (apiKey || !this.code) {
-      utils.log('SUCCESS: Authenticate (cached)')
-      return Promise.resolve(apiKey)
-    } else {
+    if (this.code) {
       utils.log('SUCCESS: Authenticate (oauth)')
-      return auth.getToken(this.code)
+      const code = this.code
+      this.code = null // Code can only be used once
+      return auth.getToken(code)
+    } else {
+      const apiKey = auth.getApiKey(true)
+      utils.log(`SUCCESS: Authenticate (cached: ${apiKey ? 'hit' : 'miss'})`)
+      return Promise.resolve(apiKey)
     }
   }
 
@@ -91,6 +93,8 @@ class TableauConnector {
         })
         .catch(() => {
           utils.log('FAILURE: Validate access')
+          // TODO forget on any 401 response
+          auth.storeApiKey('')
           tableau.abortForAuth()
         })
     } else {
@@ -114,7 +118,7 @@ class TableauConnector {
         }
 
         utils.log('START: Phase ' + tableau.phase)
-        this.updateUIWithAuthState(hasAuth)
+        this.updateUIState(tableau.phase === tableau.phaseEnum.interactivePhase)
         initCallback()
         // If we are not in the data gathering phase, we want to store the token
         // This allows us to access the token in the data gathering phase
@@ -132,8 +136,8 @@ class TableauConnector {
       })
   }
 
-  updateUIWithAuthState (hasAuth) {
-    this.uiCallback(hasAuth)
+  updateUIState (interactivePhase) {
+    this.uiCallback(interactivePhase)
   }
 
   getSchemaForDataset (resp) {
@@ -253,7 +257,7 @@ class TableauConnector {
     const {dataset, queryType} = connData
     const query = connData.query || TableauConnector.getSelectAllQuery(metadataTable)
 
-    this.redirect401(api.runQuery(dataset, query, queryType))
+    api.runQuery(dataset, query, queryType)
       .then((resp) => {
         if (connData.query) {
           if (queryType === 'sparql') {
@@ -278,7 +282,7 @@ class TableauConnector {
 
     const query = connData.query || TableauConnector.getSelectAllQuery(table.tableInfo.alias)
 
-    this.redirect401(api.runQuery(dataset, query, queryType)).then((resp) => {
+    api.runQuery(dataset, query, queryType).then((resp) => {
       const results = resp.data.results.bindings
       const columnIds = resp.data.head.vars.map((key, index) => {
         return {
@@ -316,16 +320,6 @@ class TableauConnector {
     })
   }
 
-  redirect401 (req) {
-    return req.catch(error => {
-      if (error.response && error.response.status === 401) {
-        auth.storeApiKey('')
-        auth.redirectToAuth(this.params)
-      }
-      throw (error)
-    })
-  }
-
   setConnectionData (dataset, query, queryType) {
     utils.log('START: Setting connection data')
     tableau.connectionData = JSON.stringify({
@@ -354,7 +348,13 @@ class TableauConnector {
           resolve()
         }
         reject(new Error('Dataset contains zero tables. To work in Tableu, datasets must contain at least one table.'))
-      }, reject)
+      }, error => {
+        if (error.response && error.response.status === 401) {
+          auth.redirectToAuth(this.params)
+        } else {
+          reject(error)
+        }
+      })
     })
   }
 

--- a/src/api.js
+++ b/src/api.js
@@ -19,12 +19,20 @@
 
 import axios from 'axios'
 import * as queryString from 'query-string'
-import { getApiKey } from './auth'
+import { getApiKey, storeApiKey } from './auth'
 
 const basePath = 'https://api.data.world/v0'
 const basePathQuery = 'https://query.data.world'
 
 axios.defaults.headers['Accept'] = 'application/json'
+axios.interceptors.response.use(function (response) {
+  return response
+}, function (error) {
+  if (error.response && error.response.status === 401) {
+    storeApiKey('')
+  }
+  return Promise.reject(error)
+})
 
 const runQuery = (dataset, query, queryType = 'sql') => {
   return axios.post(

--- a/src/api.js
+++ b/src/api.js
@@ -46,6 +46,16 @@ const runQuery = (dataset, query, queryType = 'sql') => {
     })
 }
 
+const getToken = (code, code_verifier) => {
+  return axios.post('https://data.world/oauth/access_token', {
+    code,
+    client_id: process.env.REACT_APP_OAUTH_CLIENT_ID,
+    client_secret: process.env.REACT_APP_OAUTH_CLIENT_SECRET,
+    grant_type: 'authorization_code',
+    code_verifier
+  })
+}
+
 const getUser = () => {
   return axios.get(
     `${basePath}/user`,
@@ -58,5 +68,6 @@ const getUser = () => {
 
 export {
   runQuery,
+  getToken,
   getUser
 }

--- a/src/api.js
+++ b/src/api.js
@@ -25,14 +25,16 @@ const basePath = 'https://api.data.world/v0'
 const basePathQuery = 'https://query.data.world'
 
 axios.defaults.headers['Accept'] = 'application/json'
-axios.interceptors.response.use(function (response) {
-  return response
-}, function (error) {
-  if (error.response && error.response.status === 401) {
-    storeApiKey('')
-  }
-  return Promise.reject(error)
-})
+axios.interceptors.response.use(
+  (response) => {
+    return response
+  },
+  (error) => {
+    if (error.response && error.response.status === 401) {
+      storeApiKey('')
+    }
+    return Promise.reject(error)
+  })
 
 const runQuery = (dataset, query, queryType = 'sql') => {
   return axios.post(

--- a/src/auth.js
+++ b/src/auth.js
@@ -17,7 +17,7 @@
  * data.world, Inc. (http://data.world/).
  */
 
-import axios from 'axios'
+import * as api from './api'
 import crypto from 'crypto'
 
 const apiTokenKey = 'DW-API-KEY'
@@ -104,14 +104,8 @@ const redirectToAuth = (state) => {
 }
 
 const getToken = (code) => {
-  return axios.post('https://data.world/oauth/access_token', {
-    code,
-    client_id: process.env.REACT_APP_OAUTH_CLIENT_ID,
-    client_secret: process.env.REACT_APP_OAUTH_CLIENT_SECRET,
-    grant_type: 'authorization_code',
-    code_verifier: useCodeVerifier()
-  }).then(response => {
-    let token
+  return api.getToken(code, useCodeVerifier()).then(response => {
+    let token = ''
     if (response.data.access_token) {
       token = response.data.access_token
     }

--- a/src/components/DatasetSelector.js
+++ b/src/components/DatasetSelector.js
@@ -25,7 +25,8 @@ class DatasetSelector extends Component {
   componentDidMount () {
     const datasetSelector = new window.dataworldWidgets.DatasetSelector({
       client_id: process.env.REACT_APP_OAUTH_CLIENT_ID,
-      hideViewButton: true
+      hideViewButton: true,
+      linkText: 'Select'
     })
 
     datasetSelector.success((datasets) => {

--- a/src/components/TableauConnectorForm.js
+++ b/src/components/TableauConnectorForm.js
@@ -106,7 +106,7 @@ class TableauConnectorForm extends Component {
       this.state.query,
       this.state.queryType)
 
-    // TODO Update window.location (push state)
+    history.pushState({}, '', '/')
 
     this.props.connector.validateParams().then(() => {
       this.props.connector.submit()

--- a/src/components/TableauConnectorForm.js
+++ b/src/components/TableauConnectorForm.js
@@ -106,6 +106,8 @@ class TableauConnectorForm extends Component {
       this.state.query,
       this.state.queryType)
 
+    // TODO Update window.location (push state)
+
     this.props.connector.validateParams().then(() => {
       this.props.connector.submit()
       this.setState({


### PR DESCRIPTION
**Problems solved:**
If token expires (or is revoked), users are no longer blocked. They can either:
1. Delete the old connection and create a new one
2. Close and re-open Tableau, after a terminal error attempting to refresh the data.world data source

**Summary of changes:**
1. Establish clear precedence for how we authenticate a request (code > local storage > password)
2. Ensure that OAuth code is discarded after it’s used (and not saved in the data source URL)
3. Make sure that auth redirect only happens in interactive mode
4. In auth phase, display only the UI that is required in order to get an updated token