### PR TITLE
Fix "The user has not yet visited the url" error

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -48,10 +48,7 @@ class App extends Component {
     this.isTableau = window.tableauVersionBootstrap || forceTableau
 
     this.state = {
-      interactivePhase: false,
-      datasetName: dataset_name,
-      query,
-      queryType
+      interactivePhase: false
     }
   }
 
@@ -62,8 +59,9 @@ class App extends Component {
   }
 
   render () {
-    const {interactivePhase, datasetName, query, queryType} = this.state
-    const dataset = datasetName ? `https://data.world/${datasetName}` : null
+    const {interactivePhase} = this.state
+    const {dataset_name, query, queryType} = this.connector.params
+    const dataset = dataset_name ? `https://data.world/${dataset_name}` : null
 
     if (!this.isTableau) {
       return (<NotTableauView />)

--- a/src/components/TableauConnectorForm.js
+++ b/src/components/TableauConnectorForm.js
@@ -106,8 +106,6 @@ class TableauConnectorForm extends Component {
       this.state.query,
       this.state.queryType)
 
-    history.pushState({}, '', '/')
-
     this.props.connector.validateParams().then(() => {
       this.props.connector.submit()
       this.setState({


### PR DESCRIPTION
Tableau stores the connector URL when a datasource is saved.
If the user needs to authenticate via OAuth, the original URL will be replaced by the final redirect URL, which contains a single-use auth code we don't want Tableau to persist.
Using `history.pushState()` was not a good solution, because Tableau won't trust URLs that the user hasn't effectively visited, which was the reason behind the "The user has not yet visited the url" error.
To overcome that, we'll replace `history.pushState()` with a proper redirect, restoring the WDCs canonical URL once the OAuth flow is completed.