### PR TITLE
Pass org id during authentication

### DIFF
--- a/src/auth.js
+++ b/src/auth.js
@@ -116,13 +116,13 @@ const getAuthUrl = (codeVerifier, state) => {
   const nonce = storeStateObject(state)
 
   const { dataset_name = '' } = state
-  const orgid =  dataset_name.split('/')[0]
-  const orgParam = orgid ? `&agentid=${orgid}` : ''
+  const agentid =  dataset_name.split('/')[0]
+  const agentidParam = agentid ? `&agentid=${agentid}` : ''
 
   return `${process.env.REACT_APP_BASE_SITE}/oauth/authorize?client_id=${process.env.REACT_APP_OAUTH_CLIENT_ID}` +
     `&redirect_uri=${process.env.REACT_APP_OAUTH_REDIRECT_URI}` +
     `&response_type=code&code_challenge_method=S256&code_challenge=${codeChallenge}` +
-    `${orgParam}` +
+    `${agentidParam}` +
     `&state=${encodeURIComponent(nonce)}`
 }
 

--- a/src/auth.js
+++ b/src/auth.js
@@ -114,9 +114,15 @@ const generateCodeChallenge = (codeVerifier) => {
 const getAuthUrl = (codeVerifier, state) => {
   const codeChallenge = generateCodeChallenge(codeVerifier)
   const nonce = storeStateObject(state)
+
+  const { dataset_name = '' } = state
+  const orgid =  dataset_name.split('/')[0]
+  const orgParam = orgid ? `&agentid=${orgid}` : ''
+
   return `${process.env.REACT_APP_BASE_SITE}/oauth/authorize?client_id=${process.env.REACT_APP_OAUTH_CLIENT_ID}` +
     `&redirect_uri=${process.env.REACT_APP_OAUTH_REDIRECT_URI}` +
     `&response_type=code&code_challenge_method=S256&code_challenge=${codeChallenge}` +
+    `${orgParam}` +
     `&state=${encodeURIComponent(nonce)}`
 }
 


### PR DESCRIPTION
When available, pass along the org id which will be used in determining whether to display the Single Sign On button.